### PR TITLE
Fixes / adds card scaling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,6 @@
 node_modules
 dist
 .hass_dev/*
-!.hass_dev/configuration.yaml
-!.hass_dev/lovelace.yaml
-!.hass_dev/lovelace-compass-showcase.yaml
-!.hass_dev/lovelace.yaml
-!.hass_dev/automations.yaml
-!.hass_dev/scripts.yaml
-!.hass_dev/scenes.yaml
-!.hass_dev/views
-!.hass_dev/www
-!.hass_dev/packages
-.hass_dev/www/community/*
 
 # Mac OS
 .DS_Store
@@ -19,3 +8,7 @@ dist
 .idea
 
 .env
+.devcontainer/ha-config/*
+.vscode/*
+package-lock.json
+.gitignore

--- a/README.md
+++ b/README.md
@@ -547,8 +547,7 @@ language: pt
 
 ## Wish/Todo list
 
-- Background image ([#12](https://github.com/tomvanswam/compass-card/issues/12))
-- Resizing compass on smaller cards ([#44](https://github.com/tomvanswam/compass-card/issues/44))
+t.b.d.
 
 ## Contact
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "compass-card",
-  "version": "2.0.2'",
+  "version": "2.1.0'",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "compass-card",
-      "version": "2.0.2'",
+      "version": "2.1.0'",
       "license": "MIT",
       "dependencies": {
         "@lit-labs/scoped-registry-mixin": "^1.0.4",

--- a/src/compass-card.ts
+++ b/src/compass-card.ts
@@ -137,17 +137,15 @@ export class CompassCard extends LitElement {
     if (!this._config || !this._hass) {
       return html``;
     }
-
     return html`
       <ha-card tabindex="0" .label=${`Compass: ${this.header.label}`} class="flex compass-card" @click=${(e) => this.handlePopup(e)}>
         ${this.showHeader() ? this.renderHeader() : ''}
 
         <div class="content">
+          <!-- Square, responsive box using aspect-ratio -->
           <div class="compass">${this.svgCompass(this.compass.north.offset)}</div>
-          <div class="sensors">
-            <div class="indicator-sensors">${this.renderDirections()}</div>
-            <div class="value-sensors">${this.renderValues()}</div>
-          </div>
+          <div class="indicator-sensors">${this.renderDirections()}</div>
+          <div class="value-sensors">${this.renderValues()}</div>
         </div>
       </ha-card>
     `;
@@ -267,7 +265,7 @@ export class CompassCard extends LitElement {
 
   private svgCompass(directionOffset: number): SVGTemplateResult {
     return svg`
-    <svg viewbox="0 0 152 152" preserveAspectRatio="xMidYMid meet" class="compass-svg">
+    <svg viewbox="0 0 152 152" preserveAspectRatio="xMidYMin meet" class="compass-svg">
       <defs>
         <pattern id="image" x="0" y="0" patternContentUnits="objectBoundingBox" height="100%" width="100%">
           <image x="0" y="0" height="1" width="1" href="${this.getBackgroundImage(this.compass.circle)}" preserveAspectRatio="xMidYMid meet"></image>

--- a/src/compass-card.ts
+++ b/src/compass-card.ts
@@ -3,6 +3,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { getLovelace, HomeAssistant, LovelaceCardEditor, LovelaceCard } from 'custom-card-helpers';
 import { HassEntities } from 'home-assistant-js-websocket';
 import { CompassCardConfig } from './editorTypes';
+
 import { CCColors, CCCompass, CCDirectionInfo, CCEntity, CCHeader, CCIndicatorSensor, CCValueSensor, CCValue, CCProperties, CCCircle } from './cardTypes';
 import handleClick from './utils/handleClick';
 
@@ -149,13 +150,16 @@ export class CompassCard extends LitElement {
     if (!this._config || !this._hass) {
       return html``;
     }
-
+    const rawSize = this._config.size ?? '100%';
+    const width = typeof rawSize === 'number' ? `${rawSize}px` : String(rawSize);
     return html`
       <ha-card tabindex="0" .label=${`Compass: ${this.header.label}`} class="flex compass-card" @click=${(e) => this.handlePopup(e)}>
         ${this.showHeader() ? this.renderHeader() : ''}
 
         <div class="content">
-          <div class="compass">${this.svgCompass(this.compass.north.offset)}</div>
+          <!-- Square, responsive box using aspect-ratio -->
+          <div class="compass" style="width:${width};">${this.svgCompass(this.compass.north.offset)}</div>
+
           <div class="indicator-sensors">${this.renderDirections()}</div>
           <div class="value-sensors">${this.renderValues()}</div>
         </div>

--- a/src/compass-card.ts
+++ b/src/compass-card.ts
@@ -89,19 +89,6 @@ export class CompassCard extends LitElement {
     this.updateConfig(this._hass, this._config);
   }
 
-  public getCardSize(): number {
-    return 4 + +this.showHeader();
-  }
-
-  public getLayoutOptions() {
-    return {
-      grid_rows: 4,
-      grid_columns: 4,
-      grid_min_rows: 3,
-      grid_min_columns: 2,
-    };
-  }
-
   set hass(hass: HomeAssistant) {
     this._hass = hass;
     this.updateConfig(this._hass, this._config);
@@ -150,18 +137,17 @@ export class CompassCard extends LitElement {
     if (!this._config || !this._hass) {
       return html``;
     }
-    const rawSize = this._config.size ?? '100%';
-    const width = typeof rawSize === 'number' ? `${rawSize}px` : String(rawSize);
+
     return html`
       <ha-card tabindex="0" .label=${`Compass: ${this.header.label}`} class="flex compass-card" @click=${(e) => this.handlePopup(e)}>
         ${this.showHeader() ? this.renderHeader() : ''}
 
         <div class="content">
-          <!-- Square, responsive box using aspect-ratio -->
-          <div class="compass" style="width:${width};">${this.svgCompass(this.compass.north.offset)}</div>
-
-          <div class="indicator-sensors">${this.renderDirections()}</div>
-          <div class="value-sensors">${this.renderValues()}</div>
+          <div class="compass">${this.svgCompass(this.compass.north.offset)}</div>
+          <div class="sensors">
+            <div class="indicator-sensors">${this.renderDirections()}</div>
+            <div class="value-sensors">${this.renderValues()}</div>
+          </div>
         </div>
       </ha-card>
     `;
@@ -281,7 +267,7 @@ export class CompassCard extends LitElement {
 
   private svgCompass(directionOffset: number): SVGTemplateResult {
     return svg`
-    <svg viewbox="0 0 152 152" preserveAspectRatio="xMidYMin meet" class="compass-svg">
+    <svg viewbox="0 0 152 152" preserveAspectRatio="xMidYMid meet" class="compass-svg">
       <defs>
         <pattern id="image" x="0" y="0" patternContentUnits="objectBoundingBox" height="100%" width="100%">
           <image x="0" y="0" height="1" width="1" href="${this.getBackgroundImage(this.compass.circle)}" preserveAspectRatio="xMidYMid meet"></image>

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,6 +1,6 @@
 import { localize } from './localize/localize';
 
-export const CARD_VERSION = '2.1.0';
+export const CARD_VERSION = '2.2.0';
 export const ICONS = {
   compass: 'mdi:compass',
 };

--- a/src/style.ts
+++ b/src/style.ts
@@ -9,14 +9,14 @@ const style: CSSResult = css`
   :host ::slotted(.card-content) {
     padding: 16px;
   }
-
   ha-card {
-    flex-direction: column;
-    flex: 1;
     position: relative;
     overflow: hidden;
+    height: 100%;
+    display: flex;
+    flex: stretch;
+    flex-direction: column;
   }
-
   .header {
     display: flex;
     justify-content: space-between;
@@ -35,54 +35,65 @@ const style: CSSResult = css`
     float: right;
   }
   .compass {
-    position: relative;
-    display: block;
-    width: 100%;
-    aspect-ratio: 1 / 1;
-    margin: 10px auto;
-    height: auto;
-    max-width: 100%;
+    flex: 1;
+    padding: 16px;
+    z-index: 1;
   }
-  .content {
-    position: relative;
+  .header ~ .compass {
+    padding-top: 0px;
+  }
+  .sensors {
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    width: calc(100% - 32px);
+    height: calc(100% - 32px);
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    z-index: 2;
+  }
+  .header ~ .sensors {
+    padding-top: 0px;
+    top: 58px;
+    height: calc(100% - 74px);
+  }
+  .compass-svg {
     width: 100%;
-    font-weight: normal;
-    line-height: 28px;
-    height: auto;
+    height: 100%;
+    overflow: visible;
   }
   .indicator-sensors,
   .value-sensors {
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    text-align: center;
     white-space: nowrap;
     text-overflow: ellipsis;
-    overflow: hidden;
-    pointer-events: none;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
   }
-  .indicator-sensors {
-    top: 20%;
-    line-height: 18px;
-    font-weight: 500;
-    font-size: 16px;
+  .indicator-sensors .abbr {
+    font-size: 1rem;
   }
-  .value-sensors {
-    top: 42%;
+  .indicator-sensors .measurement {
+    font-size: 1rem;
+  }
+  .indicator-sensors .value {
+    font-size: 1rem;
   }
   .value-sensors .measurement {
     font-size: 1rem;
   }
   .value-sensors .value {
-    font-size: 1.75rem;
+    font-size: 1rem;
   }
-  .compass-svg {
-    position: absolute;
-    inset: 0;
-    display: block;
-    width: 100%;
-    height: 100%;
-    overflow: visible;
+  [class^='sensor-'] {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: baseline;
   }
 `;
 export default style;

--- a/src/style.ts
+++ b/src/style.ts
@@ -9,14 +9,14 @@ const style: CSSResult = css`
   :host ::slotted(.card-content) {
     padding: 16px;
   }
+
   ha-card {
+    flex-direction: column;
+    flex: 1;
     position: relative;
     overflow: hidden;
-    height: 100%;
-    display: flex;
-    flex: stretch;
-    flex-direction: column;
   }
+
   .header {
     display: flex;
     justify-content: space-between;
@@ -35,65 +35,54 @@ const style: CSSResult = css`
     float: right;
   }
   .compass {
-    flex: 1;
-    padding: 16px;
-    z-index: 1;
-  }
-  .header ~ .compass {
-    padding-top: 0px;
-  }
-  .sensors {
-    padding: 16px;
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    width: calc(100% - 32px);
-    height: calc(100% - 32px);
-    align-items: center;
-    justify-content: center;
-    position: absolute;
-    z-index: 2;
-  }
-  .header ~ .sensors {
-    padding-top: 0px;
-    top: 58px;
-    height: calc(100% - 74px);
-  }
-  .compass-svg {
+    position: relative;
+    display: block;
     width: 100%;
-    height: 100%;
-    overflow: visible;
+    aspect-ratio: 1 / 1;
+    margin: 10px auto;
+    height: auto;
+    max-width: 100%;
+  }
+  .content {
+    position: relative;
+    width: 100%;
+    font-weight: normal;
+    line-height: 28px;
+    height: auto;
   }
   .indicator-sensors,
   .value-sensors {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    text-align: center;
     white-space: nowrap;
     text-overflow: ellipsis;
-    text-align: center;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
+    overflow: hidden;
+    pointer-events: none;
   }
-  .indicator-sensors .abbr {
-    font-size: 1rem;
+  .indicator-sensors {
+    top: 20%;
+    line-height: 18px;
+    font-weight: 500;
+    font-size: 16px;
   }
-  .indicator-sensors .measurement {
-    font-size: 1rem;
-  }
-  .indicator-sensors .value {
-    font-size: 1rem;
+  .value-sensors {
+    top: 42%;
   }
   .value-sensors .measurement {
     font-size: 1rem;
   }
   .value-sensors .value {
-    font-size: 1rem;
+    font-size: 1.75rem;
   }
-  [class^='sensor-'] {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: baseline;
+  .compass-svg {
+    position: absolute;
+    inset: 0;
+    display: block;
+    width: 100%;
+    height: 100%;
+    overflow: visible;
   }
 `;
 export default style;

--- a/src/style.ts
+++ b/src/style.ts
@@ -9,12 +9,14 @@ const style: CSSResult = css`
   :host ::slotted(.card-content) {
     padding: 16px;
   }
+
   ha-card {
     flex-direction: column;
     flex: 1;
     position: relative;
     overflow: hidden;
   }
+
   .header {
     display: flex;
     justify-content: space-between;
@@ -33,52 +35,54 @@ const style: CSSResult = css`
     float: right;
   }
   .compass {
+    position: relative;
     display: block;
     width: 100%;
-    height: 100%;
+    aspect-ratio: 1 / 1;
     margin: 10px auto;
+    height: auto;
+    max-width: 100%;
   }
   .content {
-    height: 152px;
     position: relative;
     width: 100%;
     font-weight: normal;
     line-height: 28px;
+    height: auto;
   }
+  .indicator-sensors,
   .value-sensors {
-    text-overflow: ellipsis;
-    white-space: nowrap;
     position: absolute;
-    text-align: center;
-    top: 62px;
     left: 50%;
     transform: translateX(-50%);
+    text-align: center;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    pointer-events: none;
   }
   .indicator-sensors {
+    top: 20%;
     line-height: 18px;
     font-weight: 500;
     font-size: 16px;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    text-align: center;
-    overflow: hidden;
-    position: absolute;
-    top: 32px;
-    left: 50%;
-    transform: translateX(-50%);
+  }
+  .value-sensors {
+    top: 42%;
   }
   .value-sensors .measurement {
-    font-size: 18px;
+    font-size: 1rem;
   }
   .value-sensors .value {
-    font-size: 28px;
+    font-size: 1.75rem;
   }
   .compass-svg {
+    position: absolute;
+    inset: 0;
+    display: block;
     width: 100%;
     height: 100%;
-    padding-bottom: 92%;
     overflow: visible;
   }
 `;
-
 export default style;


### PR DESCRIPTION
Sections view: allows to scale with rows/columns, but always rectangular, i.e. lowest value of either columns or rows steers the size
New option: ```size``` to allow to scale in non-sections view/dashboard.
alike this: 
```
type: custom:compass-card
size: 50
indicator_sensors:
  - sensor: sun.sun
    attribute: azimuth
value_sensors:
  - sensor: ""
 ```
