### PR TITLE
Allow mdi as option for indicator

### DIFF
--- a/src/cardTypes.ts
+++ b/src/cardTypes.ts
@@ -17,6 +17,8 @@ export interface CCIndicatorSensor extends CCSensor {
 
 export interface CCIndicator extends CCProperties {
   type: string;
+  size: number;
+  radius: number;
 }
 
 export interface CCHeader {

--- a/src/compass-card.ts
+++ b/src/compass-card.ts
@@ -277,7 +277,7 @@ export class CompassCard extends LitElement {
 
   private svgCompass(directionOffset: number): SVGTemplateResult {
     return svg`
-    <svg viewbox="0 0 152 152" preserveAspectRatio="xMidYMin meet" class="compass-svg">
+    <svg viewBox="0 0 152 152" preserveAspectRatio="xMidYMin meet" class="compass-svg">
       <defs>
         <pattern id="image" x="0" y="0" patternContentUnits="objectBoundingBox" height="100%" width="100%">
           <image x="0" y="0" height="1" width="1" href="${this.getBackgroundImage(this.compass.circle)}" preserveAspectRatio="xMidYMid meet"></image>
@@ -321,6 +321,9 @@ export class CompassCard extends LitElement {
       case 'circle':
         return this.svgIndicatorCircle(indicatorSensor);
       default:
+        if (indicatorSensor.indicator.type?.startsWith('mdi:')) {
+          return this.svgIndicatorMdi(indicatorSensor);
+        }
     }
     return this.svgIndicatorArrowInward(indicatorSensor);
   }
@@ -364,6 +367,32 @@ export class CompassCard extends LitElement {
         <path d="m76 5.8262v18.361a9.1809 9.1809 0 0 0 9.1556-9.1813 9.1809 9.1809 0 0 0-9.1556-9.18z" fill="${this.getColor(indicatorSensor.indicator)}"/>
         <path d="m76 5.8262v18.361a9.1809 9.1809 0 0 0 9.1556-9.1813 9.1809 9.1809 0 0 0-9.1556-9.18z" fill="white" opacity="0.5"/>
       </g>
+    `;
+  }
+
+  private svgIndicatorMdi(indicatorSensor: CCIndicatorSensor): SVGTemplateResult {
+    const icon = indicatorSensor.indicator.type as string;
+    const size = indicatorSensor?.indicator.size;
+    const r = indicatorSensor.indicator.radius;
+
+    // Compass center and place at top
+    const cx = 76;
+    const cy = 76;
+    const x = cx - size / 2;
+    const y = cy - r - size / 2;
+
+    return svg`
+      <foreignObject x=${x} y=${y} width=${size} height=${size}>
+        <ha-icon
+          .icon=${icon}
+          style="
+            --mdc-icon-size:${size}px;
+            width:${size}px; height:${size}px;
+            display:block; margin:0; padding:0;
+            pointer-events:none;
+          "
+        ></ha-icon>
+      </foreignObject>
     `;
   }
 

--- a/src/editorTypes.ts
+++ b/src/editorTypes.ts
@@ -30,6 +30,8 @@ export interface CCIndicatorSensorConfig extends CCSensorConfig {
 
 export interface CCIndicatorConfig extends CCPropertiesConfig {
   type?: string;
+  size?: number;
+  radius: number;
 }
 
 export interface CCHeaderConfig {

--- a/src/utils/objectHelpers.ts
+++ b/src/utils/objectHelpers.ts
@@ -106,6 +106,8 @@ function getIndicatorSensor(config: CompassCardConfig, colors: CCColors, indicat
       dynamic_style: getDynamicStyle(indicatorSensor.indicator?.dynamic_style, config, entities, indColor, indShow),
       color: indColor,
       show: indShow,
+      size: indicatorSensor.indicator?.size || 16,
+      radius: indicatorSensor.indicator?.radius || 60,
     },
     state_abbreviation: {
       color: abbrColor,


### PR DESCRIPTION
It replaces the circle/arrow by and mdi of choice.
The ```size``` allows to modify it and ```radius```to place it closer/further from the center.
Not fully tested and would like to combine with the compass size (which branch I lost) so will do if you add to 2.2.0

<img width="939" height="306" alt="image" src="https://github.com/user-attachments/assets/27fa3b53-3f07-43b2-b939-2fd1f1c13d46" />

<img width="938" height="189" alt="image" src="https://github.com/user-attachments/assets/ae2559d4-95f4-47cb-bd12-e946f67caef4" />

