### PR TITLE
Allow mdi, compass scaling, line thickness

### DIFF
--- a/src/cardTypes.ts
+++ b/src/cardTypes.ts
@@ -17,6 +17,8 @@ export interface CCIndicatorSensor extends CCSensor {
 
 export interface CCIndicator extends CCProperties {
   type: string;
+  size: number;
+  radius: number;
 }
 
 export interface CCHeader {
@@ -35,12 +37,14 @@ export interface CCCompass {
   east: CCProperties;
   south: CCProperties;
   west: CCProperties;
+  scale: number;
 }
 
 export interface CCCircle extends CCProperties {
   background_image: string;
   background_opacity: number;
   offset_background: boolean;
+  stroke_width: number;
 }
 
 export interface CCNorth extends CCProperties {

--- a/src/compass-card.ts
+++ b/src/compass-card.ts
@@ -149,11 +149,11 @@ export class CompassCard extends LitElement {
     if (!this._config || !this._hass) {
       return html``;
     }
+    const svgScale = this._config.compass?.scale ?? '100%';
 
     return html`
-      <ha-card tabindex="0" .label=${`Compass: ${this.header.label}`} class="flex compass-card" @click=${(e) => this.handlePopup(e)}>
+      <ha-card tabindex="0" .label=${`Compass: ${this.header.label}`} class="flex compass-card" style="--compass-card-svg-scale:${svgScale}" @click=${(e) => this.handlePopup(e)}>
         ${this.showHeader() ? this.renderHeader() : ''}
-
         <div class="compass">${this.svgCompass(this.compass.north.offset)}</div>
         <div class="sensors">
           <div class="indicator-sensors">${this.renderDirections()}</div>
@@ -296,7 +296,7 @@ export class CompassCard extends LitElement {
   }
 
   private svgCircle(directionOffset: number): SVGTemplateResult {
-    return svg`<circle class="circle" cx="76" cy="76" r="62" stroke="${this.getColor(this.compass.circle)}" stroke-width="2" fill="${this.circleFill()}" fill-opacity="
+    return svg`<circle class="circle" cx="76" cy="76" r="62" stroke="${this.getColor(this.compass.circle)}" stroke-width="${this.compass.circle.stroke_width}" fill="${this.circleFill()}" fill-opacity="
       ${this.compass.circle.background_opacity}" stroke-opacity="1.0" transform="rotate(${directionOffset},76,76)" />`;
   }
 
@@ -321,6 +321,9 @@ export class CompassCard extends LitElement {
       case 'circle':
         return this.svgIndicatorCircle(indicatorSensor);
       default:
+        if (indicatorSensor.indicator.type?.startsWith('mdi:')) {
+          return this.svgIndicatorMdi(indicatorSensor);
+        }
     }
     return this.svgIndicatorArrowInward(indicatorSensor);
   }
@@ -364,6 +367,32 @@ export class CompassCard extends LitElement {
         <path d="m76 5.8262v18.361a9.1809 9.1809 0 0 0 9.1556-9.1813 9.1809 9.1809 0 0 0-9.1556-9.18z" fill="${this.getColor(indicatorSensor.indicator)}"/>
         <path d="m76 5.8262v18.361a9.1809 9.1809 0 0 0 9.1556-9.1813 9.1809 9.1809 0 0 0-9.1556-9.18z" fill="white" opacity="0.5"/>
       </g>
+    `;
+  }
+
+  private svgIndicatorMdi(indicatorSensor: CCIndicatorSensor): SVGTemplateResult {
+    const icon = indicatorSensor.indicator.type as string;
+    const size = indicatorSensor?.indicator.size;
+    const r = indicatorSensor.indicator.radius;
+
+    // Compass center and place at top
+    const cx = 76;
+    const cy = 76;
+    const x = cx - size / 2;
+    const y = cy - r - size / 2;
+
+    return svg`
+      <foreignObject x=${x} y=${y} width=${size} height=${size}>
+        <ha-icon
+          .icon=${icon}
+          style="
+            --mdc-icon-size:${size}px;
+            width:${size}px; height:${size}px;
+            display:block; margin:0; padding:0;
+            pointer-events:none;
+          "
+        ></ha-icon>
+      </foreignObject>
     `;
   }
 

--- a/src/editorTypes.ts
+++ b/src/editorTypes.ts
@@ -30,6 +30,8 @@ export interface CCIndicatorSensorConfig extends CCSensorConfig {
 
 export interface CCIndicatorConfig extends CCPropertiesConfig {
   type?: string;
+  size?: number;
+  radius?: number;
 }
 
 export interface CCHeaderConfig {
@@ -47,12 +49,14 @@ export interface CCCompassConfig {
   east?: CCPropertiesConfig;
   south?: CCPropertiesConfig;
   west?: CCPropertiesConfig;
+  scale?: number;
 }
 
 export interface CCCircleConfig extends CCPropertiesConfig {
   background_image?: string;
   background_opacity?: number;
   offset_background?: boolean;
+  stroke_width?: number;
 }
 
 export interface CCNorthConfig extends CCPropertiesConfig {

--- a/src/utils/objectHelpers.ts
+++ b/src/utils/objectHelpers.ts
@@ -109,7 +109,7 @@ function getIndicatorSensor(config: CompassCardConfig, colors: CCColors, indicat
       dynamic_style: getDynamicStyle(indicatorSensor.indicator?.dynamic_style, config, entities, indColor, indShow),
       color: indColor,
       show: indShow,
-      size: indicatorSensor.indicator?.size || 16,
+      size: indicatorSensor.indicator?.size || 19,
       radius: indicatorSensor.indicator?.radius || 60,
     },
     state_abbreviation: {

--- a/src/utils/objectHelpers.ts
+++ b/src/utils/objectHelpers.ts
@@ -40,11 +40,14 @@ export function getCompass(config: CompassCardConfig, colors: CCColors, entities
   const bgImage = config.compass?.circle?.background_image || '';
   const bgOpacity = config.compass?.circle?.background_opacity ? config.compass?.circle?.background_opacity : config.compass?.circle?.background_image ? 1.0 : 0.0;
   const bgOffset = getBoolean(config.compass?.circle?.offset_background, true);
+  const circleStrokeWidth = config.compass?.circle?.stroke_width || 2;  
   const compass: CCCompass = {
+    scale: config.compass?.scale || 1,
     circle: {
       background_image: bgImage,
       background_opacity: bgOpacity,
       offset_background: bgOffset,
+      stroke_width: circleStrokeWidth,
       color: circleColor,
       dynamic_style: getDynamicStyle(config.compass?.circle?.dynamic_style, config, entities, circleColor, circleShow),
       show: circleShow,
@@ -106,6 +109,8 @@ function getIndicatorSensor(config: CompassCardConfig, colors: CCColors, indicat
       dynamic_style: getDynamicStyle(indicatorSensor.indicator?.dynamic_style, config, entities, indColor, indShow),
       color: indColor,
       show: indShow,
+      size: indicatorSensor.indicator?.size || 16,
+      radius: indicatorSensor.indicator?.radius || 60,
     },
     state_abbreviation: {
       color: abbrColor,


### PR DESCRIPTION
Adds :
- option to select mdi in the indicator sensor(s), allows setting size (default 19) and radius from center (0<>90, default 60)
- option to scale the compass in yaml, assist a.o. to reduce when the mdi is outside of the compass circle
- option to adjust the line thickness (default: 2)

<img width="951" height="608" alt="image" src="https://github.com/user-attachments/assets/419b3436-a76f-4a51-bfa2-8e45dce7744b" />
