### PR TITLE
Feature: allow to use images as indicator icons

### DIFF
--- a/src/cardTypes.ts
+++ b/src/cardTypes.ts
@@ -16,7 +16,8 @@ export interface CCIndicatorSensor extends CCSensor {
 }
 
 export interface CCIndicator extends CCProperties {
-  type: string;
+  icon_type: string;
+  icon_value: string;
   size: number;
   radius: number;
   scale: number;

--- a/src/compass-card.ts
+++ b/src/compass-card.ts
@@ -153,8 +153,6 @@ export class CompassCard extends LitElement {
       return html``;
     }
 
-
-
     return html`
       <ha-card tabindex="0" .label=${`Compass: ${this.header.label}`} class="flex compass-card" @click=${(e) => this.handlePopup(e)}>
         ${this.showHeader() ? this.renderHeader() : ''}
@@ -319,15 +317,21 @@ export class CompassCard extends LitElement {
   }
 
   private svgIndicator(indicatorSensor: CCIndicatorSensor): SVGTemplateResult {
-    switch (indicatorSensor.indicator.type) {
-      case 'arrow_outward':
-        return this.svgIndicatorArrowOutward(indicatorSensor);
-      case 'circle':
-        return this.svgIndicatorCircle(indicatorSensor);
-      default:
-        if (indicatorSensor.indicator.type?.startsWith('mdi:')) {
-          return this.svgIndicatorMdi(indicatorSensor);
+    switch (indicatorSensor.indicator.icon_type) {
+      case 'internal_img':
+        switch (indicatorSensor.indicator.icon_value) {
+          case 'arrow_outward':
+            return this.svgIndicatorArrowOutward(indicatorSensor);
+          case 'circle':
+            return this.svgIndicatorCircle(indicatorSensor);
+          default:
         }
+        return this.svgIndicatorArrowOutward(indicatorSensor);
+      case 'external_img':
+        return this.svgIndicatorImg(indicatorSensor);
+      case 'mdi':
+        return this.svgIndicatorMdi(indicatorSensor);
+      default:
     }
     return this.svgIndicatorArrowInward(indicatorSensor);
   }
@@ -375,7 +379,7 @@ export class CompassCard extends LitElement {
   }
 
   private svgIndicatorMdi(indicatorSensor: CCIndicatorSensor): SVGTemplateResult {
-    const icon = indicatorSensor.indicator.type as string;
+    const icon_v = indicatorSensor.indicator.icon_value as string;
     const size = indicatorSensor?.indicator.size ?? 16;
     const r = indicatorSensor.indicator.radius ?? 0;
 
@@ -391,7 +395,7 @@ export class CompassCard extends LitElement {
     return svg`
       <foreignObject x=${x} y=${y} width=${box} height=${box}>
         <ha-icon
-          .icon=${icon}
+          .icon=${icon_v}
           style="
             --mdc-icon-size:${size}px;  /* visual size you want */
             --icon-primary-color: ${this.getColor(indicatorSensor.indicator)} !important;
@@ -404,6 +408,30 @@ export class CompassCard extends LitElement {
           "
         ></ha-icon>
       </foreignObject>
+    `;
+  }
+
+  private svgIndicatorImg(indicatorSensor: CCIndicatorSensor): SVGTemplateResult {
+    const icon_v = indicatorSensor.indicator.icon_value as string;
+    const size = indicatorSensor?.indicator.size ?? 16;
+    const r = indicatorSensor.indicator.radius ?? 0;
+
+    const cx = 76;
+    const cy = 76;
+
+    const box = Math.max(size, 24);
+    const x = cx - box / 2;
+    const y = cy - r - box / 2;
+
+    return svg`
+      <image 
+        href=${icon_v} 
+        x=${x} 
+        y=${y} 
+        width=${box} 
+        height=${box} 
+        preserveAspectRatio="xMidYMid meet"
+      />
     `;
   }
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -28,3 +28,5 @@ export const UNAVAILABLE = localize('common.invalid');
 
 export const INDICATORS = ['arrow_inward', 'arrow_outward', 'circle'].sort();
 export const DEFAULT_INDICATOR = 1; // Arrow outward
+export const INDICATOR_TYPES = ['internal_img', 'external_img', 'mdi'];
+export const DEFAULT_INDICATOR_TYPE = 0; // internal_img

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -73,7 +73,7 @@ export class CompassCardEditor extends ScopedRegistryHost(LitElement) implements
 
   get _compass_indicator(): string {
     if (this._config?.indicator_sensors && this._config?.indicator_sensors.length > 0) {
-      return this._config?.indicator_sensors[0].indicator?.type || INDICATORS[DEFAULT_INDICATOR];
+      return this._config?.indicator_sensors[0].indicator?.icon_value || INDICATORS[DEFAULT_INDICATOR];
     }
     return INDICATORS[DEFAULT_INDICATOR];
   }
@@ -104,7 +104,7 @@ export class CompassCardEditor extends ScopedRegistryHost(LitElement) implements
       ${this.getEditorInput('editor.name', 'editor.optional', 'header.title.value', this._name)}
       ${this.getEditorDropDown('editor.primary entity description', 'editor.required', 'indicator_sensors[0].sensor', this._entity, entities)}
       ${this.getEditorDropDown('editor.secondary entity description', 'editor.optional', 'value_sensors[0].sensor', this._secondary_entity, optionalEntities)}
-      ${this.getEditorDropDown('editor.indicator', 'editor.optional', 'indicator_sensors[0].indicator.type', this._compass_indicator, INDICATORS)}
+      ${this.getEditorDropDown('editor.indicator', 'editor.optional', 'indicator_sensors[0].indicator.icon_value', this._compass_indicator, INDICATORS)}
       ${this.getEditorDropDown('editor.language description', 'editor.optional', 'language', this._compass_language, COMPASS_LANGUAGES)}
       ${this.getEditorInput('editor.offset description', 'editor.optional', 'compass.north.offset', this._direction_offset)}
       ${this.getEditorSwitch('directions.north', 'compass.north.show', this._compass_show_north)}
@@ -198,14 +198,14 @@ export class CompassCardEditor extends ScopedRegistryHost(LitElement) implements
             }
           }
           break;
-        case 'indicator_sensors[0].indicator.type':
-          const indicatorType: CCIndicatorConfig = { ...this._config.indicator_sensors[0]?.indicator, type: target.value };
+        case 'indicator_sensors[0].indicator.icon_value':
+          const indicatorType: CCIndicatorConfig = { ...this._config.indicator_sensors[0]?.indicator, icon_value: target.value };
           const sensorsIndicatorType = [...this._config.indicator_sensors];
           sensorsIndicatorType[0] = { ...this._config.indicator_sensors[0], indicator: indicatorType };
           this._config = { ...this._config, indicator_sensors: sensorsIndicatorType };
           if (
-            this._config.indicator_sensors[0]?.indicator?.type &&
-            INDICATORS.indexOf(this._config.indicator_sensors[0]?.indicator?.type) === DEFAULT_INDICATOR &&
+            this._config.indicator_sensors[0]?.indicator?.icon_value &&
+            INDICATORS.indexOf(this._config.indicator_sensors[0]?.indicator?.icon_value) === DEFAULT_INDICATOR &&
             Object.keys(this._config.indicator_sensors[0]?.indicator).length === 1
           ) {
             delete this._config.indicator_sensors[0].indicator;

--- a/src/editorTypes.ts
+++ b/src/editorTypes.ts
@@ -29,7 +29,8 @@ export interface CCIndicatorSensorConfig extends CCSensorConfig {
 }
 
 export interface CCIndicatorConfig extends CCPropertiesConfig {
-  type?: string;
+  icon_value?: string;
+  icon_type?: string;
   size?: number;
   radius?: number;
 }

--- a/src/updateV0ToV1.ts
+++ b/src/updateV0ToV1.ts
@@ -3,7 +3,7 @@ import { DEFAULT_INDICATOR, INDICATORS } from './const';
 import { CompassCardConfigV1 } from './editorTypes';
 
 export interface CompassCardConfigV0 extends LovelaceCardConfig {
-  type: string;
+  icon_value: string;
   name: string;
   direction_offset: string;
   entity: string;
@@ -37,7 +37,7 @@ export function configV0ToV1(dep: CompassCardConfigV0): CompassCardConfigV1 {
   const conf: CompassCardConfigV1 = { type: 'custom:compass-card', indicator_sensors: [{ sensor: dep.entity }] };
 
   if (dep.compass?.indicator && INDICATORS.indexOf(dep.compass?.indicator) !== DEFAULT_INDICATOR) {
-    conf.indicator_sensors[0] = { ...conf.indicator_sensors[0], indicator: { type: dep.compass.indicator } };
+    conf.indicator_sensors[0] = { ...conf.indicator_sensors[0], indicator: { icon_value: dep.compass.indicator } };
   }
   if (dep.secondary_entity && dep.secondary_entity !== '') {
     conf.value_sensors = [{ sensor: dep.secondary_entity }];

--- a/src/utils/objectHelpers.ts
+++ b/src/utils/objectHelpers.ts
@@ -1,5 +1,5 @@
 import { HassEntities, HassEntity } from 'home-assistant-js-websocket';
-import { DEFAULT_INDICATOR, ICONS, INDICATORS } from '../const';
+import { DEFAULT_INDICATOR, ICONS, INDICATORS, INDICATOR_TYPES, DEFAULT_INDICATOR_TYPE } from '../const';
 import { CCColors, CCCompass, CCHeader, CCIndicatorSensor, CCValueSensor, CCSensorAttrib, CCStyleBand, CCDynamicStyle } from '../cardTypes';
 import { CCDynamicStyleConfig, CCIndicatorSensorConfig, CCStyleBandConfig, CCValueSensorConfig, CompassCardConfig } from '../editorTypes';
 
@@ -92,7 +92,8 @@ function getIndicatorSensor(config: CompassCardConfig, colors: CCColors, indicat
   const attrib = indicatorSensor.attribute || '';
   const indColor = indicatorSensor.indicator?.color || colors.accent;
   const indShow = getBoolean(indicatorSensor.indicator?.show, true);
-  const indType = indicatorSensor.indicator?.type || INDICATORS[DEFAULT_INDICATOR];
+  const indIconType = indicatorSensor.indicator?.icon_type || INDICATOR_TYPES[DEFAULT_INDICATOR_TYPE];
+  const indIconValue = indicatorSensor.indicator?.icon_value || INDICATORS[DEFAULT_INDICATOR];
   const abbrColor = indicatorSensor.state_abbreviation?.color || colors.secondaryText;
   const abbrShow = getBoolean(indicatorSensor.state_abbreviation?.show, validIndex === 0);
   const valueColor = indicatorSensor.state_value?.color || colors.secondaryText;
@@ -101,7 +102,7 @@ function getIndicatorSensor(config: CompassCardConfig, colors: CCColors, indicat
   const unitsShow = getBoolean(indicatorSensor.state_units?.show, false);
   const size = indicatorSensor.indicator?.size || 19;
   const radius = indicatorSensor.indicator?.radius || 70;
-  const scale = indType.startsWith('mdi:') ? 70 / Math.max(radius, 70) : 0;
+  const scale = indIconValue.startsWith('mdi:') ? 70 / Math.max(radius, 70) : 0;
   const sensor: CCIndicatorSensor = {
     sensor: attrib === '' ? sens : sens + '.' + attrib,
     is_attribute: attrib !== '',
@@ -109,7 +110,8 @@ function getIndicatorSensor(config: CompassCardConfig, colors: CCColors, indicat
     decimals: indicatorSensor.decimals || 0,
     units: attrib !== '' ? indicatorSensor.units || '' : indicatorSensor.units || entities[sens].attributes?.unit_of_measurement || '',
     indicator: {
-      type: indType,
+      icon_type: indIconType,
+      icon_value: indIconValue,
       dynamic_style: getDynamicStyle(indicatorSensor.indicator?.dynamic_style, config, entities, indColor, indShow),
       color: indColor,
       show: indShow,


### PR DESCRIPTION
Splits the 'type' into icon_type and icon_value
Adds a renderer for images, e.g. svg, png, jpg

<img width="960" height="750" alt="image" src="https://github.com/user-attachments/assets/d510e9c5-1cc0-4122-9ba5-8c25831d9cc9" />
