### PR TITLE
make const loose

### DIFF
--- a/src/editorTypes.ts
+++ b/src/editorTypes.ts
@@ -146,6 +146,7 @@ export const LovelaceCardBaseStruct = object({
 });
 
 export const CompassCardConfigStruct = assign(
+  type({}),
   LovelaceCardBaseStruct,
   object({
     type: string(),


### PR DESCRIPTION
Add type({}) as first entry to make sure that CompassCardConfigStruct assumes a loose structure