### PR TITLE
Add compass/tickmarks as configurable option

### DIFF
--- a/src/cardTypes.ts
+++ b/src/cardTypes.ts
@@ -46,6 +46,7 @@ export interface CCHeaderItem extends CCProperties {
 
 export interface CCCompass {
   circle: CCCircle;
+  ticks: CCTicks;
   north: CCNorth;
   east: CCProperties;
   south: CCProperties;
@@ -58,6 +59,11 @@ export interface CCCircle extends CCProperties {
   background_opacity: number;
   offset_background: boolean;
   stroke_width: number;
+}
+
+export interface CCTicks extends CCProperties {
+  step: number;
+  radius: number;
 }
 
 export interface CCNorth extends CCProperties {

--- a/src/const.ts
+++ b/src/const.ts
@@ -40,6 +40,7 @@ export const DEFAULT_CIRCLE_STROKE_WIDTH = 2;
 export const DEFAULT_DECIMALS = 0;
 export const DEFAULT_INDICATOR_RADIUS = 70;
 export const DEFAULT_INDICATOR_SIZE = 19;
+export const DEFAULT_TICK_STEP = 15;
 export const DEFAULT_SECTIONS_SIZE = {
   COLUMNS_DEFAULT: 12,
   COLUMNS_MIN: 1,
@@ -48,6 +49,7 @@ export const DEFAULT_SECTIONS_SIZE = {
 };
 export const DEFAULT_START_SIZE = 0;
 export const DEGREES_MAX = 360;
+export const DEGREES_MID = 180;
 export const DEGREES_MIN = 0;
 export const DEGREES_ONE = 1;
 export const DEGREES_PER_ABBREVIATION = 22.5;
@@ -64,3 +66,7 @@ export const OPACITY_VISIBLE = 1;
 export const RADIUS_TO_DIAMETER_FACTOR = 2;
 export const SVG_SCALE_MAX = 100;
 export const SVG_SCALE_MIN = 0;
+export const TICK_LENGTH_DIFF_2 = 2;
+export const TICK_LENGTH_DIFF_4 = 4;
+export const TICK_LENGTH_DIFF_8 = 8;
+export const TICK_ANGLE = 30;

--- a/src/editorTypes.ts
+++ b/src/editorTypes.ts
@@ -1,5 +1,5 @@
 import { array, assign, boolean, enums, Infer, number, object, optional, pattern, refine, size, string, type, union } from 'superstruct';
-import { DEGREES_MAX, DEGREES_MIN, ICON_VALUES, MAX_INDICATOR_ARRAY_SIZE, MAX_PERCENTAGE, MIN_INDICATOR_ARRAY_SIZE, MIN_PERCENTAGE, OPACITY_TRANSPARENT, OPACITY_VISIBLE } from './const.js';
+import { DEGREES_MAX, DEGREES_MID, DEGREES_MIN, ICON_VALUES, MAX_INDICATOR_ARRAY_SIZE, MAX_PERCENTAGE, MIN_INDICATOR_ARRAY_SIZE, MIN_PERCENTAGE, OPACITY_TRANSPARENT, OPACITY_VISIBLE } from './const.js';
 import { COMPASS_LANGUAGES } from './localize/localize.js';
 import { LovelaceCardConfig } from 'custom-card-helpers';
 
@@ -85,6 +85,15 @@ export const CCNorthConfigStruct = assign(
 );
 export type CCNorthConfig = Infer<typeof CCNorthConfigStruct>;
 
+export const CCTicksConfigStruct = assign(
+  CCPropertiesConfigStruct,
+  object({
+    radius: optional(number()),    
+    step: optional(numberBetween(DEGREES_MIN, DEGREES_MID)),
+  }),
+);
+export type CCTicksConfig = Infer<typeof CCNorthConfigStruct>;
+
 export const CCEntityConfigStruct = object({
   attribute: optional(string()),
   decimals: optional(number()),
@@ -143,6 +152,7 @@ export const CCCompassConfigStruct = object({
   north: optional(CCNorthConfigStruct),
   scale: optional(number()),
   south: optional(CCPropertiesConfigStruct),
+  ticks: optional(CCTicksConfigStruct),
   west: optional(CCPropertiesConfigStruct),
 });
 export type CCCompassConfig = Infer<typeof CCCompassConfigStruct>;

--- a/src/style.ts
+++ b/src/style.ts
@@ -167,6 +167,22 @@ const style: CSSResult = css`
   .value-sensor[class^='sensor-']:not(:first-child) {
     margin-top: -0.8rem;
   }
+  .compass__ticks {
+    stroke: var(--compass-card-tick-color, var(--primary-text-color));
+    stroke-linecap: round;
+  }
+  .compass__tick {
+    stroke-width: 0.7;
+    opacity: 0.7;
+  }
+  .compass__tick--major {
+    stroke-width: 1.2;
+    opacity: 0.7;
+  }
+  .compass__tick--minor {
+    stroke-width: 0.7;
+    opacity: 0.7;
+  }
 `;
 
 export default style;

--- a/src/utils/objectHelpers.ts
+++ b/src/utils/objectHelpers.ts
@@ -1,6 +1,6 @@
 import { CCColors, CCCompass, CCDynamicStyle, CCHeader, CCIndicatorSensor, CCSensorAttrib, CCStyleBand, CCValueSensor } from '../cardTypes.js';
 import { CCDynamicStyleConfig, CCIndicatorSensorConfig, CCStyleBandConfig, CCValueSensorConfig, CompassCardConfig } from '../editorTypes.js';
-import { DEFAULT_CIRCLE_STROKE_WIDTH, DEFAULT_DECIMALS, DEFAULT_ICON_VALUE, DEFAULT_INDICATOR_RADIUS, DEFAULT_INDICATOR_SIZE, DEFAULT_START_SIZE, DEGREES_MIN, ICON_VALUES, ICONS, INDEX_ELEMENT_0, LENGTH_TO_INDEX, NO_ELEMENTS, OPACITY_TRANSPARENT, OPACITY_VISIBLE, SVG_SCALE_MIN } from '../const.js';
+import { DEFAULT_CIRCLE_STROKE_WIDTH, DEFAULT_DECIMALS, DEFAULT_ICON_VALUE, DEFAULT_INDICATOR_RADIUS, DEFAULT_INDICATOR_SIZE, DEFAULT_START_SIZE, DEFAULT_TICK_STEP, DEGREES_MIN, ICON_VALUES, ICONS, INDEX_ELEMENT_0, LENGTH_TO_INDEX, NO_ELEMENTS, OPACITY_TRANSPARENT, OPACITY_VISIBLE, SVG_SCALE_MIN } from '../const.js';
 import { HassEntities, HassEntity } from 'home-assistant-js-websocket';
 
 export function getBoolean(value: boolean | number | string | undefined, defValue: boolean): boolean {
@@ -136,6 +136,10 @@ export function getCompass(config: CompassCardConfig, colors: CCColors, entities
   const southShow = getBoolean(config.compass?.south?.show, false);
   const westColor = config.compass?.west?.color || colors.primary;
   const westShow = getBoolean(config.compass?.west?.show, false);
+  const ticksColor = config.compass?.ticks?.color || colors.primary;
+  const ticksShow = getBoolean(config.compass?.ticks?.show, false);
+  const ticksRadius = config.compass?.ticks?.radius || DEFAULT_INDICATOR_RADIUS;
+  const ticksStep = config.compass?.ticks?.step || DEFAULT_TICK_STEP;
   const bgImage = config.compass?.circle?.background_image || '';
   const bgOpacity = config.compass?.circle?.background_opacity ? config.compass?.circle?.background_opacity : config.compass?.circle?.background_image ? OPACITY_VISIBLE : OPACITY_TRANSPARENT;
   const bgOffset = getBoolean(config.compass?.circle?.offset_background, true);
@@ -167,6 +171,13 @@ export function getCompass(config: CompassCardConfig, colors: CCColors, entities
       dynamic_style: getDynamicStyle(config.compass?.south?.dynamic_style, config, entities, southColor, southShow),
       show: southShow,
     },
+    ticks: {
+      color: ticksColor,
+      dynamic_style: getDynamicStyle(config.compass?.ticks?.dynamic_style, config, entities, ticksColor, ticksShow),
+      radius: ticksRadius,
+      show: ticksShow,
+      step: ticksStep,
+    },    
     west: {
       color: westColor,
       dynamic_style: getDynamicStyle(config.compass?.west?.dynamic_style, config, entities, westColor, westShow),


### PR DESCRIPTION
Add ticks as a separete configurable option, next to the compass circle

## Summary by Sourcery

Add configurable tick marks around the compass card as a separate visual layer controlled by the compass configuration.

New Features:
- Introduce a configurable compass ticks layer that can be toggled independently of the compass circle.
- Allow customization of tick mark color, radius, and angular step via the compass.ticks configuration.

Enhancements:
- Extend compass configuration, types, and validation schemas to support the new ticks options with sensible defaults.
- Add styling for major and minor compass tick marks to visually differentiate them.